### PR TITLE
User context is now an object

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ function App() {
 
   return (
     <ThemeProvider theme={theme}>
-      <UserCtx.Provider value={[user, setUser, removeUser]}>
+      <UserCtx.Provider value={{user, setUser, removeUser}}>
         <CssBaseline />
         <Bar />
         {user ? <Steps /> : null}

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -7,7 +7,7 @@ import { createUserFromJson } from '../../transformers/user.transformer';
 const CLIENT_ID = process.env.REACT_APP_GOOGLE_ID || '';
 
 const Login = () => {
-  const [, setUser] = useContext(UserCtx);
+  const { setUser } = useContext(UserCtx);
 
   function responseGoogle(response: any) {
     const loggedUser: User = createUserFromJson(response);

--- a/src/components/Auth/LogoutButton.tsx
+++ b/src/components/Auth/LogoutButton.tsx
@@ -3,7 +3,8 @@ import React, { memo, useContext } from 'react';
 import { UserCtx } from '../../contexts/user.context';
 
 const LogoutButton = () => {
-  const [, , removeUser] = useContext(UserCtx);
+  const { removeUser } = useContext(UserCtx);
+
   return (
     <Button variant="outlined" color="inherit" onClick={removeUser}>
       Log out

--- a/src/components/Bar.tsx
+++ b/src/components/Bar.tsx
@@ -19,7 +19,7 @@ const styles = {
 
 const Bar: FunctionComponent = () => {
   const classes = useStyles(styles);
-  const [user] = useContext(UserCtx);
+  const { user } = useContext(UserCtx);
 
   return (
     <div className={classes.root}>

--- a/src/components/Hello.tsx
+++ b/src/components/Hello.tsx
@@ -11,8 +11,12 @@ const styles = (theme: Theme) => ({
 });
 
 const Hello = () => {
-  const [user] = useContext(UserCtx);
+  const { user } = useContext(UserCtx);
   const classes = useStyles(styles);
+
+  if (!user) {
+    return null;
+  }
 
   return (
     <Typography variant="overline" color="inherit" className={classes.hello}>

--- a/src/components/SendEmailButton.tsx
+++ b/src/components/SendEmailButton.tsx
@@ -9,10 +9,12 @@ interface OwnProps {
 }
 
 const SendEmailButton: FunctionComponent<OwnProps> = ({ rcps }) => {
-  const [user] = useContext(UserCtx);
+  const { user } = useContext(UserCtx);
 
   const click = () => {
-    send(rcps, user);
+    if (user) {
+      send(rcps, user);
+    }
   };
 
   return (

--- a/src/contexts/user.context.ts
+++ b/src/contexts/user.context.ts
@@ -1,3 +1,13 @@
 import { createContext } from 'react';
+import { User } from '../models';
 
-export const UserCtx = createContext(null as any);
+export interface UserContext {
+  readonly setUser: (user: User) => void;
+  readonly removeUser: () => void;
+  readonly user?: User;
+}
+
+export const UserCtx = createContext<UserContext>({
+  removeUser: () => null,
+  setUser: () => null,
+});


### PR DESCRIPTION
It's easier to manage context if it's an object. You can easily grab objects inside using destructuring object. Doing the same with spread operator on array gets difficult when you have multiple objects in your array. Quick example: 

Using spread operator on array with multiple objects / functions
```tsx
// Passing an array
 <UserCtx.Provider value={[setUser, doSomething, test, user, setUser, logout]}>
```

```ts
const MyComponent: FunctionComponent = () => {
  const [,,, user,,logout] = useContext(UserCtx);
}
```

And this is how it looks when you use object destructuring
```tsx
// Passing an object
 <UserCtx.Provider value={{setUser, doSomething, test, user, setUser, logout}}>
```

```ts
const MyComponent: FunctionComponent = () => {
  const { user, logout} = useContext(UserCtx);
}
```
