### PR TITLE
Refactored Spreadsheet Context

### DIFF
--- a/src/components/DrivePicker.tsx
+++ b/src/components/DrivePicker.tsx
@@ -31,7 +31,7 @@ const styles = (theme: Theme) => ({
 });
 
 const DrivePicker = () => {
-  const [spreadsheet, setSpreadsheet] = useContext(SpreadsheetCtx);
+  const { spreadsheet, setSpreadsheet } = useContext(SpreadsheetCtx);
   const [step, setStep] = useContext(StepCtx);
   const classes = useStyles(styles);
   const service = new SpreadSheetService();

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -22,7 +22,7 @@ const styles = (theme: Theme) => ({
 
 const Editor = () => {
   const [mailTemplate, setMailTemplate] = useContext(MailTemplateCtx);
-  const [spreadsheet] = useContext(SpreadsheetCtx);
+  const { spreadsheet } = useContext(SpreadsheetCtx);
   const [editor, setEditor] = useState(
     EditorState.createWithContent(stateFromHTML(mailTemplate)),
   );

--- a/src/components/Sender/Recipients.tsx
+++ b/src/components/Sender/Recipients.tsx
@@ -17,7 +17,7 @@ const styles = {
 
 const Recipients = () => {
   const classes = useStyles(styles);
-  const [spreadsheet, setSpreadsheet] = useContext(SpreadsheetCtx);
+  const { spreadsheet, setSpreadsheet } = useContext(SpreadsheetCtx);
 
   function onChange(
     event: React.ChangeEvent<HTMLInputElement>,

--- a/src/components/Stepper/Steps.tsx
+++ b/src/components/Stepper/Steps.tsx
@@ -26,7 +26,7 @@ const Steps = () => {
   }
 
   return (
-    <SpreadsheetCtx.Provider value={[spreadsheet, setSpreadsheet]}>
+    <SpreadsheetCtx.Provider value={{spreadsheet, setSpreadsheet}}>
       <MailTemplateCtx.Provider value={[mailTemplate, setMailTemplate]}>
         <StepCtx.Provider value={[activeStep, setActiveStep]}>
           <Stepper


### PR DESCRIPTION
`useContext` hook uses `Context` object created [here](https://github.com/SoftwareBrothers/mailinger/compare/spreadsheet-context-refactor?expand=1#diff-f841e14633141a1f8aa923612a18d174R29). You can treat this line as 

```ts
const contextProviderValue = {
  spreadsheet: spreadsheet,
  setSpreadsheet: setSpreadsheet
};
```

Thus when you want to obtain `spreadsheet` object, you do it this way:

```ts
const spreadsheet = contextProviderValue.spreadsheet;
```

Or using [destructuring](http://exploringjs.com/es6/ch_destructuring.html):

```ts
const { spreadsheet } = contextProviderValue;
```